### PR TITLE
typo `end` -> `hand`

### DIFF
--- a/golem.Rmd
+++ b/golem.Rmd
@@ -85,7 +85,7 @@ This `DESCRIPTION` file will be filled automatically by the first function you'l
 In other words, most of the time you won't interact with it directly, but through wrappers from `{golem}` and `{usethis}`.
 
 The `NAMESPACE` file is one of the most important file in your package. 
-It's also the one you'll NEVER edit by end!
+It's also the one you'll NEVER edit by hand!
 R uses this one to define how to interact with the rest of the library: what function to import and from which package and what function to export, i.e what functions are available when you do `library(golex)`. 
 This file will be built when running the documenting process in your R package: `{roxygen2}` will scan all your `.R` files, and build the `man/` + the `NAMESPACE`, by scanning the roxygen tags there. 
 


### PR DESCRIPTION
Typo in section 4.2.1